### PR TITLE
Fix package repo by adding missing git parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: frr
 on: push
 jobs:
   build_pkg:
-    uses: gardenlinux/package-build/.github/workflows/build_pkg.yml@feature/29-create-changelog
+    uses: gardenlinux/package-build/.github/workflows/build_pkg.yml@main
     with:
       source: git+https://github.com/FRRouting/frr.git#master
       debian_source: native

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,12 @@ name: frr
 on: push
 jobs:
   build_pkg:
-    uses: gardenlinux/package-build/.github/workflows/build_pkg.yml@main
+    uses: gardenlinux/package-build/.github/workflows/build_pkg.yml@feature/29-create-changelog
     with:
       source: git+https://github.com/FRRouting/frr.git#master
       debian_source: native
       tag_suffix: frr-
-      tag_mangle: "rc|dev"
+      tag_mangel: "rc|dev"
         #      dependencies: |
         #gardenlinux/package-libyang2@libyang2_2.1.111-1gl0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,5 @@ jobs:
     with:
       source: git+https://github.com/FRRouting/frr.git#master
       debian_source: native
-      tag_suffix: frr-
-      tag_mangel: "rc|dev"
-        #      dependencies: |
-        #gardenlinux/package-libyang2@libyang2_2.1.111-1gl0
-
+      git_filter: 'frr\-[0-9\.]*$'
+      git_tag_match: 'frr\-([0-9\.]*).*'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the `package-frr` repo by adding two missing parameters:
* `git_filter`
* `git_tag_match`

