### PR TITLE
Use Github dependencies instead of Garden Linux ones

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,3 +8,5 @@ jobs:
       debian_source: native
       git_filter: 'frr\-[0-9\.]*$'
       git_tag_match: 'frr\-([0-9\.]*).*'
+      build_dependencies: |
+        gardenlinux/package-libyang2@latest


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that we use our own `libyang2` from Github.

**Which issue(s) this PR fixes**:
Fixes #2 
