### PR TITLE
use libyang3

### DIFF
--- a/patches/series
+++ b/patches/series
@@ -1,1 +1,2 @@
 no-sphinx.patch
+use-libyang3.patch

--- a/patches/use-libyang3.patch
+++ b/patches/use-libyang3.patch
@@ -1,0 +1,12 @@
+diff --color -Naur a/debian/control b/debian/control
+--- a/debian/control	2025-04-23 12:29:23
++++ b/debian/control	2025-04-23 12:32:47
+@@ -23,7 +23,7 @@
+                librtr-dev (>= 0.8.0~) <!pkg.frr.nortrlib>,
+                libsnmp-dev,
+                libssh-dev <!pkg.frr.nortrlib>,
+-               libyang2-dev (>= 2.1.128) | libyang-dev ( >= 3.0.3),
++               libyang-dev ( >= 3.0.3),
+                lsb-base,
+                pkg-config,
+                protobuf-c-compiler,

--- a/prepare_source
+++ b/prepare_source
@@ -1,2 +1,3 @@
 git_src -b frr-10.3 https://github.com/FRRouting/frr.git
 apply_patches
+version_suffix=gl1


### PR DESCRIPTION
**What this PR does / why we need it**:
- Debian testing dropped libyang2.
- We need 10.3 frr, debian only has 10.2 

This PR patches the control file to only use libyang-dev which is the libyang3 equivalent name. 

I assume this is a fix, because the way we pull in dependencies in repo build can currently not handle the | operator (not confirmed).

https://github.com/gardenlinux/repo/blob/79ad0a024b7b46e191611cea9ab628531551ce2b/download_pkgs#L37C22-L37C29




**Which issue(s) this PR fixes**:
Fixes nightly apt repo depency for frr package
